### PR TITLE
update to 1.36.4

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -100,7 +100,17 @@ cmake ${CMAKE_ARGS} ..  \
       -DgRPC_ZLIB_PROVIDER="package" \
       -DgRPC_ABSL_PROVIDER="package" \
       -DgRPC_RE2_PROVIDER="package" \
+      -DCMAKE_AR=${AR} \
+      -DCMAKE_RANLIB=${RANLIB} \
+      -DCMAKE_VERBOSE_MAKEFILE=ON \
       -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc
 
-ninja install
+ninja install -v
+
+
+# These are in conflict with the re2 package.
+rm -rf ${PREFIX}/include/re2
+rm -rf ${PREFIX}/lib/libre2.a
+rm -rf ${PREFIX}/lib/pkgconfig/re2.pc
+
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,11 +18,6 @@ build:
   run_exports:
     - {{ pin_subpackage('grpc-cpp', max_pin='x.x') }}
   ignore_run_exports:
-    - abseil-cpp
-    - c-ares
-    - re2
-    - openssl
-    - zlib
     - libgcc-ng
     - libstdcxx-ng
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,11 @@ build:
   run_exports:
     - {{ pin_subpackage('grpc-cpp', max_pin='x.x') }}
   ignore_run_exports:
+    - abseil-cpp
+    - c-ares
+    - re2
+    - openssl
+    - zlib
     - libgcc-ng
     - libstdcxx-ng
 
@@ -53,6 +58,17 @@ requirements:
     # Use pins to control cos6/cos7 match
     - libgcc-ng  {{ libgcc }}
     - libstdcxx-ng  {{ libstdcxx }}
+
+test:
+  files:
+    - tests/include/*
+  commands:
+    - grpc_cpp_plugin < /dev/null
+
+    - test -f $PREFIX/lib/libgrpc.so
+    - test -f $PREFIX/lib/libgrpc_unsecure.so
+    - test -f $PREFIX/lib/libgrpc++.so
+    - test -f $PREFIX/lib/libgrpc++_unsecure.so
 
 about:
   home: https://grpc.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grpc-cpp" %}
-{% set version = "1.29.1" %}
+{% set version = "1.36.4" %}
 
 package:
   name: {{ name | lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://github.com/grpc/grpc/archive/v{{ version }}.tar.gz
-  sha256: 0343e6dbde66e9a31c691f2f61e98d79f3584e03a11511fad3f10e3667832a45
+  sha256: 8eb9d86649c4d4a7df790226df28f081b97a62bf12c5c5fe9b5d31a29cd6541a
   patches:
     - aarch64-tcp-header.patch  # [aarch64]
     - force-protoc-executable.patch
 
 build:
-  number: 3
+  number: 1
   string: h{{ PKG_HASH }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   run_exports:
     - {{ pin_subpackage('grpc-cpp', max_pin='x.x') }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Update grpc-cpp to 1.36.4 to match up with protobuf 3.14.
Anaconda's defaults does have 1.36.4, but it only contains the static libs, which ends up causing problems in the arrow build related to undefined abseil-cpp symbols so let's build our own that includes the shared libs.

requires: https://github.com/open-ce/open-ce/pull/451

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
