### PR TITLE
Remove libgcc runtime pins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,10 @@ source:
     - force-protoc-executable.patch
 
 build:
-  number: 3
+  number: 4
   string: h{{ PKG_HASH }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   run_exports:
     - {{ pin_subpackage('grpc-cpp', max_pin='x.x') }}
-  ignore_run_exports:
-    - libgcc-ng
-    - libstdcxx-ng
 
 requirements:
   build:
@@ -50,9 +47,6 @@ requirements:
     - libstdcxx-ng  {{ libstdcxx }}
   run:
     - zlib
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
 
 about:
   home: https://grpc.io/


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any tests to validate this change?

## Description

Adjust libgcc and libstdc++ runtime dependencies for xgboost

open-ce/open-ce#452


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
