### PR TITLE
fix build for 1.3 and 1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,8 @@ requirements:
     - libprotobuf {{ protobuf }}
     - ninja
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}            # [x86_64 and c_compiler_version == "7.2.*"]
-    - libstdcxx-ng  {{ libstdcxx }}      # [x86_64 and c_compiler_version == "7.2.*"]
+    - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
     # We need all host deps also in build for cross-compiling
     - abseil-cpp  # [build_platform != target_platform]
     - c-ares      # [build_platform != target_platform]
@@ -45,7 +45,7 @@ requirements:
     - c-ares
     - libprotobuf {{ protobuf }}
     - re2
-    - openssl         # [not (x86_64 and c_compiler_version == "7.5.*")]
+    - openssl     # [not (x86_64 and c_compiler_version == "7.2.*")]
     - zlib
     # Use pins to control cos6/cos7 match
     - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - force-protoc-executable.patch
 
 build:
-  number: 1
+  number: 2
   string: h{{ PKG_HASH }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   run_exports:
     - {{ pin_subpackage('grpc-cpp', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,12 +45,12 @@ requirements:
     - c-ares
     - libprotobuf {{ protobuf }}
     - re2
-    - openssl 1.1.1k  # [x86_64 and c_compiler_version == "7.2.*"]
-    - openssl         # [ppc64le or (x86_64 and c_compiler_version == "7.5.*")]
+    - openssl         # [not (x86_64 and c_compiler_version == "7.5.*")]
     - zlib
     # Use pins to control cos6/cos7 match
     - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
     - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
+    - openssl 1.1.1k                  # [x86_64 and c_compiler_version == "7.2.*"]
   run:
     - zlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,11 @@ build:
   string: h{{ PKG_HASH }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   run_exports:
     - {{ pin_subpackage('grpc-cpp', max_pin='x.x') }}
+  ignore_run_exports:
+    - abseil-cpp
+    - openssl
+    - re2
+    - c-ares
 
 requirements:
   build:
@@ -27,8 +32,8 @@ requirements:
     - libprotobuf {{ protobuf }}
     - ninja
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
+    - libgcc-ng  {{ libgcc }}            # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}      # [x86_64 and c_compiler_version == "7.2.*"]
     # We need all host deps also in build for cross-compiling
     - abseil-cpp  # [build_platform != target_platform]
     - c-ares      # [build_platform != target_platform]
@@ -40,11 +45,12 @@ requirements:
     - c-ares
     - libprotobuf {{ protobuf }}
     - re2
-    - openssl
+    - openssl 1.1.1k  # [x86_64 and c_compiler_version == "7.2.*"]
+    - openssl         # [ppc64le or (x86_64 and c_compiler_version == "7.5.*")]
     - zlib
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
+    - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
   run:
     - zlib
 


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

The latest openssl packages on x86 have been built with the new Anaconda toolchain.
This PR will pin to an older openSSL at build time when using the old toolchain and allow newer SSLs when using the newer toolchain.
This also cleans up some of the run exports

closes #6 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
