### PR TITLE
fix buid for 1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - force-protoc-executable.patch
 
 build:
-  number: 4
+  number: 5
   string: h{{ PKG_HASH }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   run_exports:
     - {{ pin_subpackage('grpc-cpp', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - libprotobuf {{ protobuf }}
     - ninja
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
+    - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
     # We need all host deps also in build for cross-compiling
     - abseil-cpp  # [build_platform != target_platform]
     - c-ares      # [build_platform != target_platform]
@@ -40,11 +40,12 @@ requirements:
     - c-ares
     - libprotobuf {{ protobuf }}
     - re2
-    - openssl
+    - openssl                         # [not (x86_64 and c_compiler_version == "7.2.*")]
     - zlib
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
+    - libgcc-ng  {{ libgcc }}        # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}  # [x86_64 and c_compiler_version == "7.2.*"]
+    - openssl 1.1.1k                 # [x86_64 and c_compiler_version == "7.2.*"]
   run:
     - zlib
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

The latest openssl packages on x86 have been built with the new Anaconda toolchain.
This PR will pin to an older openSSL at build time when using the old toolchain and allow newer SSLs when using the newer toolchain.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
