### PR TITLE
[1.2] pin c-ares and zlib to fix build failure

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - force-protoc-executable.patch
 
 build:
-  number: 5
+  number: 6
   string: h{{ PKG_HASH }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   run_exports:
     - {{ pin_subpackage('grpc-cpp', max_pin='x.x') }}
@@ -31,17 +31,17 @@ requirements:
     - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
     # We need all host deps also in build for cross-compiling
     - abseil-cpp  # [build_platform != target_platform]
-    - c-ares      # [build_platform != target_platform]
+    - c-ares 1.17.1
     - re2         # [build_platform != target_platform]
     - openssl     # [build_platform != target_platform]
-    - zlib        # [build_platform != target_platform]
+    - zlib {{zlib}} h7b6447c_3
   host:
     - abseil-cpp  {{ abseil_cpp }}
-    - c-ares
+    - c-ares 1.17.1
     - libprotobuf {{ protobuf }}
     - re2
     - openssl                         # [not (x86_64 and c_compiler_version == "7.2.*")]
-    - zlib
+    - zlib {{zlib}} h7b6447c_3
     # Use pins to control cos6/cos7 match
     - libgcc-ng  {{ libgcc }}        # [x86_64 and c_compiler_version == "7.2.*"]
     - libstdcxx-ng  {{ libstdcxx }}  # [x86_64 and c_compiler_version == "7.2.*"]


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Update recipe to pin the following packages:

- `zlib` to `1.2.11 h7b6447c_3`
- `c-ares` to `1.17.1`

to avoid pulling newer versions of these packages.  The newer versions are causing the following failures:
```
$PREFIX/lib/libz.so: undefined reference to `memcpy@GLIBC_2.14'
$BUILD_PREFIX/lib/libcares.so.2.5.1: undefined reference to `memcpy@GLIBC_2.14'
$BUILD_PREFIX/lib/libcares.so.2.5.1: undefined reference to `clock_gettime@GLIBC_2.17'
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
